### PR TITLE
fix: remove cleanup job that breaks multi-arch images

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -514,46 +514,6 @@ jobs:
         draft: false
         prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-alpha') }}
 
-  # Cleanup old images
-  cleanup:
-    needs: [build-and-push, security-scan, integration-test]
-    runs-on: ubuntu-latest
-    if: always()
-
-    steps:
-    - name: Delete untagged images
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const packages = ['elder-api', 'elder-web', 'elder-scanner', 'elder-connector'];
-
-          for (const pkg of packages) {
-            try {
-              const response = await github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg({
-                package_type: 'container',
-                package_name: pkg,
-                org: context.repo.owner,
-                per_page: 100
-              });
-
-              const untaggedVersions = response.data.filter(version =>
-                version.metadata.container.tags.length === 0
-              );
-
-              for (const version of untaggedVersions) {
-                console.log(`Deleting untagged version: ${version.id} for ${pkg}`);
-                await github.rest.packages.deletePackageVersionForOrg({
-                  package_type: 'container',
-                  package_name: pkg,
-                  org: context.repo.owner,
-                  package_version_id: version.id,
-                });
-              }
-            } catch (error) {
-              console.log(`Error cleaning up ${pkg}: ${error.message}`);
-            }
-          }
-
   # Deploy to Kubernetes cluster
   deploy-k8s:
     needs: [build-and-push, integration-test]


### PR DESCRIPTION
## Problem

The `cleanup` job in `docker-build.yml` was deleting **all untagged container images** after every build. This broke multi-arch images because:

1. `docker/build-push-action` pushes amd64 and arm64 images as **untagged** blobs
2. It creates a tagged manifest list (e.g., `v3.0.5`) referencing those untagged images
3. The cleanup job deleted all untagged images immediately
4. The manifest list then referenced non-existent images

This caused errors like:
```
Error parsing manifest for image: fetching target platform image
selected from image index: reading manifest sha256:xxx: manifest unknown
```

## Solution

Remove the cleanup job entirely. For container image retention, use GitHub's built-in package retention settings:
- Settings → Packages → Default retention policy

## After merging

The existing broken manifests won't self-heal. A fresh build/push is needed to create working images.

## Summary by Sourcery

CI:
- Delete the GitHub Actions cleanup job that removed all untagged container images from the container registry.