### PR TITLE
chore: update beta values to gamma image tags (v3.2.3)

### DIFF
--- a/k8s/helm/elder/values-beta.yaml
+++ b/k8s/helm/elder/values-beta.yaml
@@ -61,7 +61,7 @@ web:
   replicaCount: 2
   image:
     repository: ghcr.io/penguintechinc/elder-web
-    tag: 3.2.1.1776737340-beta
+    tag: 3.2.1.1776737340-gamma
     pullPolicy: Always
   buildArgs:
     VITE_API_URL: ""
@@ -84,7 +84,7 @@ api:
   replicaCount: 2
   image:
     repository: ghcr.io/penguintechinc/elder-api
-    tag: 3.2.1.1776737340-beta
+    tag: 3.2.1.1776737340-gamma
     pullPolicy: Always
   env:
     FLASK_ENV: production
@@ -118,7 +118,7 @@ scanner:
   replicaCount: 2
   image:
     repository: ghcr.io/penguintechinc/elder-scanner
-    tag: 3.2.1.1776737340-beta
+    tag: 3.2.1.1776737340-gamma
     pullPolicy: Always
   env:
     SCANNER_POLL_INTERVAL: "300"
@@ -139,7 +139,7 @@ worker:
   replicaCount: 2
   image:
     repository: ghcr.io/penguintechinc/elder-worker
-    tag: 3.2.1.1776737340-beta
+    tag: 3.2.1.1776737340-gamma
     pullPolicy: Always
   env:
     LOG_LEVEL: INFO


### PR DESCRIPTION
## Summary

- Updates `values-beta.yaml` to track v3.2.3 gamma images deployed to dal2-beta
- All 4 services (`web`, `api`, `scanner`, `worker`) pointing at `3.2.1.1776737340-gamma`
- Beta cluster healthy: all 11 pods running post-deploy

## Test plan

- [x] Beta deploy verified: `kubectl get pods -n elder` all Running
- [x] API responding (HTTP 403 on auth-required endpoints = expected)
- [x] No regressions — all pods stable for 4h+ post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Deployment:
- Point beta environment web, api, scanner, and worker services to the 3.2.1.1776737340-gamma image tags.