### PR TITLE
feat: wire in penguin-aaa (RBAC, tenant + audit middleware)

### DIFF
--- a/apps/api/auth/decorators.py
+++ b/apps/api/auth/decorators.py
@@ -7,10 +7,11 @@ import inspect
 from functools import wraps
 from typing import Callable, List
 
-from quart import current_app, g, jsonify, request
 from penguin_dal import Row
+from quart import current_app, g, jsonify, request
 
 from apps.api.auth.jwt_handler import get_current_user
+from apps.api.auth.rbac import check_org_permission, check_permission, enforcer
 
 
 def login_required(f: Callable) -> Callable:
@@ -233,41 +234,75 @@ def org_permission_required(permission_name: str, org_id_param: str = "id") -> C
 
 
 def _check_user_permission(user: Row, permission_name: str) -> bool:
-    """
-    Check if user has a specific permission (global or org-scoped).
-
-    Args:
-        user: PyDAL Row representing identity
-        permission_name: Permission name to check
-
-    Returns:
-        True if user has permission (currently simplified - returns True for all authenticated users)
-
-    TODO: Implement full RBAC permission checking with PyDAL
-    """
-    # Simplified permission check - superusers have all permissions
-    # For non-superusers, we'll need to implement RBAC tables and logic
-    # For now, allow authenticated users to proceed
-    return True
+    """Check if user has a specific permission using RBACEnforcer."""
+    return check_permission(user, permission_name)
 
 
 def _check_org_permission(user: Row, permission_name: str, org_id: int) -> bool:
+    """Check if user has permission in an organization context."""
+    return check_org_permission(user, permission_name, org_id)
+
+
+def require_scope(scope: str) -> Callable:
+    """Require a specific scope claim on the current request.
+
+    Reads ``g.claims["scope"]`` populated by the before_request bridge in main.py.
+    Returns 403 if the scope is absent. Must be placed after ``@login_required``.
+
+    Usage::
+
+        @bp.route("/secrets")
+        @login_required
+        @require_scope("secrets:read")
+        async def list_secrets():
+            ...
     """
-    Check if user has permission for a specific organization.
 
-    Args:
-        user: PyDAL Row representing identity
-        permission_name: Permission name to check
-        org_id: Organization ID
+    def decorator(f: Callable) -> Callable:
+        @wraps(f)
+        async def wrapper(*args, **kwargs):
+            claims = getattr(g, "claims", {}) or {}
+            granted = set(claims.get("scope", []))
+            if getattr(g, "current_user", None) and getattr(
+                g.current_user, "is_superuser", False
+            ):
+                pass  # superusers bypass scope checks
+            elif scope not in granted:
+                return jsonify({"error": f"Missing required scope: '{scope}'"}), 403
+            if inspect.iscoroutinefunction(f):
+                return await f(*args, **kwargs)
+            return f(*args, **kwargs)
 
-    Returns:
-        True if user has permission for this organization (currently simplified)
+        return wrapper
 
-    TODO: Implement full organization-scoped RBAC with PyDAL
+    return decorator
+
+
+def require_role(role: str) -> Callable:
+    """Require a specific role on the current request.
+
+    Reads ``g.claims["roles"]`` populated by the before_request bridge in main.py.
+    Returns 403 if the role is absent. Must be placed after ``@login_required``.
     """
-    # Simplified org permission check
-    # For now, allow authenticated users to proceed
-    return True
+
+    def decorator(f: Callable) -> Callable:
+        @wraps(f)
+        async def wrapper(*args, **kwargs):
+            claims = getattr(g, "claims", {}) or {}
+            granted = set(claims.get("roles", []))
+            if getattr(g, "current_user", None) and getattr(
+                g.current_user, "is_superuser", False
+            ):
+                pass
+            elif role not in granted:
+                return jsonify({"error": f"Missing required role: '{role}'"}), 403
+            if inspect.iscoroutinefunction(f):
+                return await f(*args, **kwargs)
+            return f(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
 
 
 def resource_role_required(required_role: str, resource_param: str = "id") -> Callable:

--- a/apps/api/auth/jwt_handler.py
+++ b/apps/api/auth/jwt_handler.py
@@ -8,8 +8,8 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 import jwt
-from quart import current_app, g, request
 from penguin_dal import Row
+from quart import current_app, g, request
 from werkzeug.security import check_password_hash
 
 logger = logging.getLogger(__name__)
@@ -31,13 +31,22 @@ def generate_token(identity: Row, token_type: str = "access") -> str:
     else:
         expires_delta = current_app.config["JWT_REFRESH_TOKEN_EXPIRES"]
 
+    from apps.api.auth.rbac import role_scopes
+
+    portal_role = getattr(identity, "portal_role", "observer") or "observer"
+    tenant = str(getattr(identity, "tenant_id", "") or "")
+
     now = datetime.now(timezone.utc)
     payload = {
-        "sub": str(identity.id),  # JWT spec requires sub to be a string
+        "sub": str(identity.id),
         "username": identity.username,
         "type": token_type,
         "iat": now,
         "exp": now + expires_delta,
+        # penguin-aaa compatible claims — enables RBAC and tenant middleware
+        "tenant": tenant,
+        "roles": [portal_role],
+        "scope": role_scopes(portal_role) if token_type == "access" else [],
     }
 
     secret = current_app.config["JWT_SECRET_KEY"] or current_app.config["SECRET_KEY"]

--- a/apps/api/auth/rbac.py
+++ b/apps/api/auth/rbac.py
@@ -1,0 +1,132 @@
+"""Elder RBAC — roles, scopes, and permission enforcement via penguin-aaa."""
+
+from penguin_aaa.authz.rbac import RBACEnforcer, Role
+
+# ---------------------------------------------------------------------------
+# Scope catalogue — resource:action format
+# ---------------------------------------------------------------------------
+
+_OBSERVER_SCOPES = [
+    "audit:read",
+    "certificates:read",
+    "data-stores:read",
+    "dependencies:read",
+    "discovery:read",
+    "entities:read",
+    "iam:read",
+    "issues:read",
+    "keys:read",
+    "networking:read",
+    "organizations:read",
+    "projects:read",
+    "sbom:read",
+    "secrets:read",
+    "software:read",
+    "vulnerabilities:read",
+    "webhooks:read",
+]
+
+_EDITOR_SCOPES = _OBSERVER_SCOPES + [
+    "certificates:write",
+    "data-stores:write",
+    "dependencies:write",
+    "discovery:write",
+    "entities:write",
+    "iam:write",
+    "issues:write",
+    "keys:write",
+    "networking:write",
+    "organizations:write",
+    "projects:write",
+    "sbom:write",
+    "secrets:write",
+    "software:write",
+    "vulnerabilities:write",
+    "webhooks:write",
+    "users:read",
+]
+
+_ADMIN_SCOPES = _EDITOR_SCOPES + [
+    "audit:write",
+    "config:write",
+    "entities:delete",
+    "issues:delete",
+    "keys:delete",
+    "organizations:delete",
+    "secrets:delete",
+    "users:write",
+    "users:delete",
+]
+
+# ---------------------------------------------------------------------------
+# Enforcer singleton — imported by decorators and permission helpers
+# ---------------------------------------------------------------------------
+
+enforcer = RBACEnforcer()
+enforcer.register(Role("observer", _OBSERVER_SCOPES))
+enforcer.register(Role("editor", _EDITOR_SCOPES))
+enforcer.register(Role("admin", _ADMIN_SCOPES))
+
+# ---------------------------------------------------------------------------
+# Legacy permission name → scope mapping
+# Used by _check_user_permission to bridge old-style permission strings
+# ---------------------------------------------------------------------------
+
+PERMISSION_SCOPE_MAP: dict[str, str] = {
+    "manage_users": "users:write",
+    "view_users": "users:read",
+    "create_entity": "entities:write",
+    "edit_entity": "entities:write",
+    "delete_entity": "entities:delete",
+    "view_entity": "entities:read",
+    "create_organization": "organizations:write",
+    "edit_organization": "organizations:write",
+    "delete_organization": "organizations:delete",
+    "view_organization": "organizations:read",
+    "manage_secrets": "secrets:write",
+    "view_secrets": "secrets:read",
+    "manage_keys": "keys:write",
+    "view_keys": "keys:read",
+    "manage_discovery": "discovery:write",
+    "view_discovery": "discovery:read",
+    "view_audit": "audit:read",
+    "manage_iam": "iam:write",
+    "view_iam": "iam:read",
+    "manage_webhooks": "webhooks:write",
+    "edit_config": "config:write",
+}
+
+
+def check_permission(user, permission_name: str) -> bool:
+    """Return True if user's role grants the named permission.
+
+    Superusers always pass. For everyone else, the permission name is mapped
+    to a scope via PERMISSION_SCOPE_MAP and checked against the enforcer.
+    Unknown permissions default to False.
+    """
+    if getattr(user, "is_superuser", False):
+        return True
+    scope = PERMISSION_SCOPE_MAP.get(permission_name)
+    if not scope:
+        return False
+    role = getattr(user, "portal_role", "observer") or "observer"
+    return enforcer.has_scope(role, scope)
+
+
+def check_org_permission(user, permission_name: str, org_id: int) -> bool:
+    """Return True if user's role grants the permission in any org context.
+
+    Elder does not yet have per-org role rows for identities (only for
+    portal users via resource_roles). Until that's wired, fall back to the
+    global role check so behaviour is consistent with check_permission.
+    """
+    return check_permission(user, permission_name)
+
+
+def role_scopes(portal_role: str) -> list[str]:
+    """Return the scope list for a portal_role string, defaulting to observer."""
+    role = portal_role if portal_role in ("observer", "editor", "admin") else "observer"
+    try:
+        return enforcer.scopes_for_role(role)
+    except KeyError:
+        return []

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -7,8 +7,12 @@ import logging
 import os
 
 import structlog
+from penguin_aaa.audit.emitter import Emitter
+from penguin_aaa.audit.sinks import StdoutSink
+from penguin_aaa.middleware.asgi import AuditMiddleware
+from penguin_aaa.middleware.tenant import TenantMiddleware
 from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, generate_latest
-from quart import Quart, jsonify, make_response
+from quart import Quart, g, jsonify, make_response
 from quart_cors import cors
 
 from apps.api.config import get_config
@@ -130,7 +134,51 @@ def create_app(config_name: str = None) -> Quart:
         version=app.config["APP_VERSION"],
     )
 
+    _register_before_request(app)
+
     return app
+
+
+def create_asgi_app(config_name: str = None):
+    """Return a production-ready ASGI callable wrapped with penguin-aaa middleware.
+
+    Layer order (outermost first):
+      AuditMiddleware → TenantMiddleware → Quart app
+
+    Use this as the uvicorn entry point. Tests can use ``create_app()`` directly
+    to get the bare Quart app and call ``app.test_client()``.
+    """
+    quart_app = create_app(config_name)
+    emitter = Emitter(StdoutSink())
+    asgi = TenantMiddleware(quart_app, required=False)
+    asgi = AuditMiddleware(asgi, emitter)
+    return asgi
+
+
+def _register_before_request(app: Quart) -> None:
+    """Populate g.claims from the JWT payload on every authenticated request.
+
+    This bridges Elder's Bearer-token auth into the penguin-aaa claims format
+    so that @require_scope / @require_role decorators work without an extra DB
+    round-trip — the scopes and roles are embedded in the token itself.
+    """
+
+    @app.before_request
+    async def populate_claims():
+        from apps.api.auth.jwt_handler import get_token_from_header, verify_token
+
+        token = get_token_from_header()
+        if not token:
+            return
+        payload = verify_token(token)
+        if not payload:
+            return
+        g.claims = {
+            "sub": payload.get("sub", ""),
+            "tenant": payload.get("tenant", ""),
+            "roles": payload.get("roles", []),
+            "scope": payload.get("scope", []),
+        }
 
 
 _metrics_registry = CollectorRegistry(auto_describe=True)
@@ -454,7 +502,7 @@ if __name__ == "__main__":
     import uvicorn
 
     uvicorn.run(
-        create_app(),
+        create_asgi_app(),
         host=os.getenv("HOST", "0.0.0.0"),
         port=int(os.getenv("PORT", 5000)),
     )

--- a/requirements.in
+++ b/requirements.in
@@ -120,6 +120,7 @@ types-pytz==2024.2.0.20241003
 python-ldap==3.4.5
 
 # PenguinTech Shared Libraries (penguin-libs)
+penguin-aaa==0.1.0
 penguin-libs~=0.1.0
 penguin-licensing~=0.1.0
 penguin-utils~=0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1806,6 +1806,10 @@ pathspec==1.0.4 \
     --hash=sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645 \
     --hash=sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723
     # via black
+penguin-aaa==0.1.0 \
+    --hash=sha256:4d894db11879f8adab6cb30229e5525c7eaa2fca1efd665da337eb07fff74caf \
+    --hash=sha256:d410eb578cf206cf13cbaa20deeda29d1a6cd0412c8406bb65ad473adb46cce4
+    # via -r requirements.in
 penguin-dal==0.3.0 \
     --hash=sha256:6f598d3131fcdffe1f1ab003f83d63952a1d5447bf8a2140e5a33d38a19085ca \
     --hash=sha256:16b679b5a9fadb825b48c9dd58c779c1418757b9353c9085957d7340489d950d


### PR DESCRIPTION
## Summary

- **`apps/api/auth/rbac.py`** (new): `RBACEnforcer` singleton with `observer` / `editor` / `admin` roles defined in `resource:action` scope format. `PERMISSION_SCOPE_MAP` bridges legacy permission strings (`manage_users`, `view_users`, etc.) to scopes. `check_permission()` replaces the `_check_user_permission` stub that previously returned `True` for everyone.
- **`apps/api/auth/jwt_handler.py`**: `generate_token()` now embeds `tenant`, `roles`, and `scope` in the JWT payload — existing tokens without these fields still work (they just won't carry scope/role info until re-issued).
- **`apps/api/auth/decorators.py`**: stubs replaced with real `enforcer.has_scope()` calls; adds `@require_scope` and `@require_role` Quart-native decorators that read `g.claims` (no extra DB round-trip).
- **`apps/api/main.py`**: `create_asgi_app()` wraps Quart with `TenantMiddleware(required=False)` then `AuditMiddleware(StdoutSink)`. A `before_request` hook populates `g.claims` from the decoded JWT so decorators work without touching the DB.
- **`requirements.in` / `requirements.txt`**: adds `penguin-aaa==0.1.0`.

## ASGI middleware stack

```
uvicorn
  └── AuditMiddleware       ← emits JSON audit event per request to stdout
        └── TenantMiddleware (required=False)  ← extracts tenant claim when present
              └── Quart app
                    └── before_request: g.claims populated from JWT
                          └── route handler
```

`TenantMiddleware` runs in non-required mode because Elder's own JWTs now carry `tenant` only after fresh login — older tokens without it still pass through. Switch to `required=True` once all tokens are re-issued.

## What's NOT changed

- All 30+ blueprint files — zero changes to route handlers
- `@login_required` behavior — still validates against the DB
- `@resource_role_required` — still queries `resource_roles` table (unchanged)

## Test plan

- [ ] `POST /api/v1/auth/login` → returned token now contains `tenant`, `roles`, `scope` fields
- [ ] `GET /api/v1/identities` with `observer` role token → 403 (no `users:read` scope... wait, observer has `users:read` — use `manage_users` endpoint) → test with non-admin identity hits `@permission_required("manage_users")` → 403
- [ ] Superuser bypass: `is_superuser=True` → all permissions pass regardless of role
- [ ] Audit log: each request emits a JSON line to stdout with subject, action, path, status_code
- [ ] CI lint and build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Integrate role- and scope-based authorization and tenant/audit middleware into the API, wiring JWT claims into request context for RBAC-aware access control.

New Features:
- Add RBACEnforcer-based role and scope definitions with legacy permission-to-scope mapping for portal roles.
- Embed tenant, roles, and scope claims into issued JWTs based on the identity's portal role to support downstream RBAC and tenancy.
- Introduce decorators to enforce required scopes or roles on routes using JWT-derived claims without extra database lookups.
- Provide an ASGI factory that wraps the Quart app with tenant and audit middleware and exposes claims via a before_request hook.

Enhancements:
- Replace permissive permission stubs with RBAC-backed helpers for global and organization-level permission checks.
- Run the development server using the new ASGI app factory instead of the bare Quart app.
- Add penguin-aaa as a dependency for authorization and middleware support.